### PR TITLE
Fix syntax error in semantic selector for article extraction

### DIFF
--- a/app/services/news_service.py
+++ b/app/services/news_service.py
@@ -156,8 +156,7 @@ class UniversalArticleScraper:
             "main article",
             '[role="main"] article',
             "main",
--            '[role="main]',
-+            '[role="main"]',
+            '[role="main"]',
         ]
 
         for selector in semantic_selectors:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue with extracting content from elements marked with `role="main"` to improve accuracy in news parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->